### PR TITLE
v1.4.0 dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### v1.4.0 (2018-04-12):
+
+Dependency upgrades! No new features.
+
+ - Changes our `componentWillUpdate` call to `componentDidUpdate` to eliminate a
+   React 16.3 StrictMode warning
+ - Migration to [react-transition-group](https://github.com/reactjs/react-transition-group) v2
+ - Switches from lodash 3 to lodash 4
+ - Changes demo to use React 16.3
+
+There still are StrictMode warnings due to `react-transition-group` still using
+the older APIs.
+
 ### v1.3.3 (2017-05-19):
 
 Fixes incorrect timer clearing. (Thanks, @dmeiz1)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ details about why and how we built this.
 
 See the [live demo](http://google-fabric.github.io/velocity-react/).
 
-**Latest version:** v1.3.3 fixes timer clearing bug on unmount of VelocityTransitionGroup
+**Latest version:** v1.4.0 Removes some React 16.3 deprecations and warnings
 
 *Note: v1.1.0 and later require React 0.14.x*
 *Note: v1.3.0 and later require React 15.3.x and should work with React 16*

--- a/demo/examples/scrolling-group.jsx
+++ b/demo/examples/scrolling-group.jsx
@@ -7,54 +7,82 @@ var Box = require('../components/box');
 var EmojiSpan = require('../components/emoji-span');
 
 var CATS = ['😸', '😹', '😺', '😻', '😼', '😽', '😾', '😿', '🙀'];
-var FOODS = ['🍅', '🍆', '🍇', '🍈', '🍉', '🍊', '🍌', '🍍', '🍎', '🍏', '🍑', '🍒', '🍓', '🍔', '🍕', '🍖', '🍗'];
-
+var FOODS = [
+  '🍅',
+  '🍆',
+  '🍇',
+  '🍈',
+  '🍉',
+  '🍊',
+  '🍌',
+  '🍍',
+  '🍎',
+  '🍏',
+  '🍑',
+  '🍒',
+  '🍓',
+  '🍔',
+  '🍕',
+  '🍖',
+  '🍗',
+];
 
 var Animations = {
   // Register these with UI Pack so that we can use stagger later.
   In: velocityHelpers.registerEffect({
     calls: [
-      [{
-        transformPerspective: [ 800, 800 ],
-        transformOriginX: [ '50%', '50%' ],
-        transformOriginY: [ '100%', '100%' ],
-        marginBottom: 0,
-        opacity: 1,
-        rotateX: [0, 130],
-      }, 1, {
-        easing: 'ease-out',
-        display: 'block',
-      }]
+      [
+        {
+          transformPerspective: [800, 800],
+          transformOriginX: ['50%', '50%'],
+          transformOriginY: ['100%', '100%'],
+          marginBottom: 0,
+          opacity: 1,
+          rotateX: [0, 130],
+        },
+        1,
+        {
+          easing: 'ease-out',
+          display: 'block',
+        },
+      ],
     ],
   }),
 
   Out: velocityHelpers.registerEffect({
     calls: [
-      [{
-        transformPerspective: [ 800, 800 ],
-        transformOriginX: [ '50%', '50%' ],
-        transformOriginY: [ '0%', '0%' ],
-        marginBottom: -30,
-        opacity: 0,
-        rotateX: -70,
-      }, 1, {
-        easing: 'ease-out',
-        display: 'block',
-      }]
+      [
+        {
+          transformPerspective: [800, 800],
+          transformOriginX: ['50%', '50%'],
+          transformOriginY: ['0%', '0%'],
+          marginBottom: -30,
+          opacity: 0,
+          rotateX: -70,
+        },
+        1,
+        {
+          easing: 'ease-out',
+          display: 'block',
+        },
+      ],
     ],
   }),
 };
 
+const newItem = i => {
+  return {
+    title: [_.sample(CATS)].concat(_.sample(FOODS, _.random(1, 4))).join(' '),
+    i,
+  };
+};
+
 class ScrollingGroup extends React.Component {
   state = {
-    itemCount: 0,
-    items: [],
+    itemCount: 1,
+    items: [newItem(0)],
     duration: 500,
   };
-
-  componentWillMount() {
-    this.whenAddButtonClicked();
-  }
 
   whenAddButtonClicked = () => {
     this.addRows(1);
@@ -64,19 +92,15 @@ class ScrollingGroup extends React.Component {
     this.addRows(5);
   };
 
-  whenOptionClicked = (event) => {
+  whenOptionClicked = event => {
     this.setState({ duration: parseInt(event.target.value) });
   };
 
-  addRows = (count) => {
+  addRows = count => {
     var items = this.state.items;
 
     for (var i = 0; i < count; ++i) {
-      var item = {
-        title: [_.sample(CATS)].concat(_.sample(FOODS, _.random(1, 4))).join(' '),
-        i: this.state.itemCount + i,
-      };
-
+      var item = newItem(i + this.state.itemCount);
       items = [item].concat(items);
     }
 
@@ -87,15 +111,20 @@ class ScrollingGroup extends React.Component {
   };
 
   render() {
-    var rows = this.state.items.map(function (item, i, arr) {
+    var rows = this.state.items.map(function(item, i, arr) {
       var itemStyle = {
         width: 150,
         padding: '0 10px',
         lineHeight: '30px',
-        backgroundColor: (item.i % 2 == 0) ? Box.COLORS.backColor : Box.COLORS.underneathColor,
+        backgroundColor:
+          item.i % 2 == 0 ? Box.COLORS.backColor : Box.COLORS.underneathColor,
       };
 
-      return (<div key={item.i} style={itemStyle}><EmojiSpan>{item.title}</EmojiSpan></div>);
+      return (
+        <div key={item.i} style={itemStyle}>
+          <EmojiSpan>{item.title}</EmojiSpan>
+        </div>
+      );
     });
 
     var groupStyle = {
@@ -129,17 +158,37 @@ class ScrollingGroup extends React.Component {
           <button onClick={this.whenAdd5ButtonClicked}>Add 5 Rows</button>
         </div>
 
-        <VelocityTransitionGroup component="div" className="flex-1" style={groupStyle} enter={enterAnimation} leave={leaveAnimation}>
+        <VelocityTransitionGroup
+          component="div"
+          className="flex-1"
+          style={groupStyle}
+          enter={enterAnimation}
+          leave={leaveAnimation}
+        >
           {rows}
         </VelocityTransitionGroup>
 
-        <form style={{fontSize: 12}}>
+        <form style={{ fontSize: 12 }}>
           <label>
-            <input type="radio" name="speed" value={500} checked={this.state.duration === 500} onChange={this.whenOptionClicked}/> Fast
+            <input
+              type="radio"
+              name="speed"
+              value={500}
+              checked={this.state.duration === 500}
+              onChange={this.whenOptionClicked}
+            />{' '}
+            Fast
           </label>
           &nbsp;
           <label>
-            <input type="radio" name="speed" value={2000} checked={this.state.duration === 2000} onChange={this.whenOptionClicked}/> Slow
+            <input
+              type="radio"
+              name="speed"
+              value={2000}
+              checked={this.state.duration === 2000}
+              onChange={this.whenOptionClicked}
+            />{' '}
+            Slow
           </label>
         </form>
       </div>

--- a/demo/examples/toggle-box.jsx
+++ b/demo/examples/toggle-box.jsx
@@ -1,7 +1,6 @@
 var React = require('react');
 var createReactClass = require('create-react-class');
 var VelocityComponent = require('../../src/velocity-component');
-var tweenState = require('react-tween-state');
 var s = require('underscore.string');
 
 var Box = require('../components/box');
@@ -38,9 +37,7 @@ var EFFECTS = [
 var ToggleBox = createReactClass({
   displayName: 'ToggleBox',
 
-  mixins: [ tweenState.Mixin ],
-
-  getInitialState: function () {
+  getInitialState: function() {
     return {
       effect: EFFECTS[0],
       isIn: true,
@@ -49,87 +46,138 @@ var ToggleBox = createReactClass({
     };
   },
 
-  componentWillMount: function () {
+  componentDidMount: function() {
     // Tweening shows how animations work given re-renders
     this.startTweening();
   },
 
-  startTweening: function () {
-    this.tweenState('counter', {
-      duration: 5000,
-      endValue: 100,
-      onEnd: this.reverseTweening,
-    });
+  componentWillUnmount: function() {
+    this.stopTweening();
   },
 
-  reverseTweening: function () {
-    this.tweenState('counter', {
-      duration: 5000,
-      endValue: 0,
-      onEnd: this.startTweening,
-    });
+  startTweening: function() {
+    this.tweenInterval = setInterval(() => {
+      if (this.state.counter === 99) {
+        this.setState({ counter: 0 });
+      } else {
+        this.setState({ counter: this.state.counter + 1 });
+      }
+    }, 100);
   },
 
-  whenToggleClicked: function () {
+  stopTweening: function() {
+    clearInterval(this.tweenInterval);
+  },
+
+  whenToggleClicked: function() {
     this.setState({
       isIn: !this.state.isIn,
     });
   },
 
-  whenSelectChanged: function (evt) {
+  whenSelectChanged: function(evt) {
     this.setState({
       effect: evt.target.value,
       isIn: true,
     });
   },
 
-  whenOptionChanged: function (evt) {
+  whenOptionChanged: function(evt) {
     this.setState({ interruptBehavior: evt.target.value });
   },
 
-  render: function () {
-    var animation = 'transition.' + this.state.effect + (this.state.isIn ? 'In' : 'Out');
+  render: function() {
+    var animation =
+      'transition.' + this.state.effect + (this.state.isIn ? 'In' : 'Out');
 
     return (
       <div className="flex-box flex-column flex-1 align-items-center">
         <div>
-          <select value={this.state.effect} onChange={this.whenSelectChanged}>{this.renderEffects()}</select>
+          <select value={this.state.effect} onChange={this.whenSelectChanged}>
+            {this.renderEffects()}
+          </select>
         </div>
         <div className="flex-1">
-          <Box className="flex-1 flex-box flex-column align-items-center" style={{backgroundColor: '#f5f5f5'}} onClick={this.whenToggleClicked} instruction="Click!">
+          <Box
+            className="flex-1 flex-box flex-column align-items-center"
+            style={{ backgroundColor: '#f5f5f5' }}
+            onClick={this.whenToggleClicked}
+            instruction="Click!"
+          >
             {/*
               Use of key here keeps the component (and its set styles) from persisting across effects.
               Avoids flashing when switching effects.
             */}
-            <VelocityComponent key={this.state.effect} animation={animation} interruptBehavior={this.state.interruptBehavior}>
-              <Box>{Math.floor(this.getTweeningValue('counter'))}</Box>
+            <VelocityComponent
+              key={this.state.effect}
+              animation={animation}
+              interruptBehavior={this.state.interruptBehavior}
+            >
+              <Box>{this.state.counter}</Box>
             </VelocityComponent>
           </Box>
         </div>
-        <div style={{ fontStyle: 'italic', fontSize: '11px', padding: '0px 30px 10px', textAlign: 'center' }}>
-          Number counting to show the [non-]effects of rapid re-rendering on the animation.
+        <div
+          style={{
+            fontStyle: 'italic',
+            fontSize: '11px',
+            padding: '0px 30px 10px',
+            textAlign: 'center',
+          }}
+        >
+          Number counting to show the [non-]effects of rapid re-rendering on the
+          animation.
         </div>
         <div style={{ fontSize: 12 }}>
-          <h4 style={{ marginBottom: 4, fontWeight: 'bold', textAlign: 'center'}}>Interruption Behavior</h4>
+          <h4
+            style={{ marginBottom: 4, fontWeight: 'bold', textAlign: 'center' }}
+          >
+            Interruption Behavior
+          </h4>
           <label>
-            <input type="radio" name="interruptBehavior" value="stop" checked={this.state.interruptBehavior === 'stop'} onChange={this.whenOptionChanged}/> Stop
+            <input
+              type="radio"
+              name="interruptBehavior"
+              value="stop"
+              checked={this.state.interruptBehavior === 'stop'}
+              onChange={this.whenOptionChanged}
+            />{' '}
+            Stop
           </label>
           &nbsp;&nbsp;
           <label>
-            <input type="radio" name="interruptBehavior" value="finish" checked={this.state.interruptBehavior === 'finish'} onChange={this.whenOptionChanged}/> Finish
+            <input
+              type="radio"
+              name="interruptBehavior"
+              value="finish"
+              checked={this.state.interruptBehavior === 'finish'}
+              onChange={this.whenOptionChanged}
+            />{' '}
+            Finish
           </label>
           &nbsp;&nbsp;
           <label>
-            <input type="radio" name="interruptBehavior" value="queue" checked={this.state.interruptBehavior === 'queue'} onChange={this.whenOptionChanged}/> Queue
+            <input
+              type="radio"
+              name="interruptBehavior"
+              value="queue"
+              checked={this.state.interruptBehavior === 'queue'}
+              onChange={this.whenOptionChanged}
+            />{' '}
+            Queue
           </label>
         </div>
       </div>
     );
   },
 
-  renderEffects: function () {
-    return EFFECTS.map(function (effect) {
-      return (<option key={effect} value={effect}>{s.titleize(s.humanize(effect))}</option>);
+  renderEffects: function() {
+    return EFFECTS.map(function(effect) {
+      return (
+        <option key={effect} value={effect}>
+          {s.titleize(s.humanize(effect))}
+        </option>
+      );
     });
   },
 });

--- a/demo/examples/trigger-box.jsx
+++ b/demo/examples/trigger-box.jsx
@@ -7,14 +7,7 @@ var EmojiSpan = require('../components/emoji-span');
 
 var PALS = ['👫', '👬', '👭'];
 
-var EFFECTS = [
-  'bounce',
-  'shake',
-  'flash',
-  'pulse',
-  'swing',
-  'tada',
-];
+var EFFECTS = ['bounce', 'shake', 'flash', 'pulse', 'swing', 'tada'];
 
 class TriggerBox extends React.Component {
   state = {
@@ -22,6 +15,8 @@ class TriggerBox extends React.Component {
     chain: 'stop',
     palIndex: 0,
   };
+
+  velocityRef = React.createRef();
 
   whenClicked = () => {
     this.setState({
@@ -33,17 +28,17 @@ class TriggerBox extends React.Component {
       stop: this.state.chain === 'stop',
     };
 
-    this.refs.velocity.runAnimation(opts);
+    this.velocityRef.current.runAnimation(opts);
   };
 
-  whenSelectChanged = (evt) => {
+  whenSelectChanged = evt => {
     this.setState({
       effect: evt.target.value,
       isIn: true,
     });
   };
 
-  whenOptionChanged = (evt) => {
+  whenOptionChanged = evt => {
     this.setState({ chain: evt.target.value });
   };
 
@@ -53,31 +48,62 @@ class TriggerBox extends React.Component {
     return (
       <div className="flex-box flex-column flex-1 align-items-center">
         <div>
-          <select value={this.state.effect} onChange={this.whenSelectChanged}>{this.renderEffects()}</select>
+          <select value={this.state.effect} onChange={this.whenSelectChanged}>
+            {this.renderEffects()}
+          </select>
         </div>
         <div className="flex-1">
           {/*
             Use of key here keeps the component (and its set styles) from persisting across effects.
             Avoids flashing when switching effects.
           */}
-          <VelocityComponent ref="velocity" key={this.state.effect} animation={animation}>
+          <VelocityComponent
+            ref={this.velocityRef}
+            key={this.state.effect}
+            animation={animation}
+          >
             <Box onClick={this.whenClicked} instruction="Click!">
               <EmojiSpan size={72}>{PALS[this.state.palIndex]}</EmojiSpan>
             </Box>
           </VelocityComponent>
         </div>
         <div style={{ fontSize: 12 }}>
-          <h4 style={{ marginBottom: 4, fontWeight: 'bold', textAlign: 'center'}}>Interruption Behavior</h4>
+          <h4
+            style={{ marginBottom: 4, fontWeight: 'bold', textAlign: 'center' }}
+          >
+            Interruption Behavior
+          </h4>
           <label>
-            <input type="radio" name="chain" value="stop" checked={this.state.chain === 'stop'} onChange={this.whenOptionChanged}/> Stop
+            <input
+              type="radio"
+              name="chain"
+              value="stop"
+              checked={this.state.chain === 'stop'}
+              onChange={this.whenOptionChanged}
+            />{' '}
+            Stop
           </label>
           &nbsp;&nbsp;
           <label>
-            <input type="radio" name="chain" value="finish" checked={this.state.chain === 'finish'} onChange={this.whenOptionChanged}/> Finish
+            <input
+              type="radio"
+              name="chain"
+              value="finish"
+              checked={this.state.chain === 'finish'}
+              onChange={this.whenOptionChanged}
+            />{' '}
+            Finish
           </label>
           &nbsp;&nbsp;
           <label>
-            <input type="radio" name="chain" value="queue" checked={this.state.chain === 'queue'} onChange={this.whenOptionChanged}/> Queue
+            <input
+              type="radio"
+              name="chain"
+              value="queue"
+              checked={this.state.chain === 'queue'}
+              onChange={this.whenOptionChanged}
+            />{' '}
+            Queue
           </label>
         </div>
       </div>
@@ -85,8 +111,12 @@ class TriggerBox extends React.Component {
   }
 
   renderEffects = () => {
-    return EFFECTS.map(function (effect) {
-      return (<option key={effect} value={effect}>{s.titleize(s.humanize(effect))}</option>);
+    return EFFECTS.map(function(effect) {
+      return (
+        <option key={effect} value={effect}>
+          {s.titleize(s.humanize(effect))}
+        </option>
+      );
     });
   };
 }

--- a/demo/main.jsx
+++ b/demo/main.jsx
@@ -43,13 +43,25 @@ class Demo extends React.Component {
 class MainComponent extends React.Component {
   render() {
     return (
-      <div className="flex-box flex-wrap">
-        <Demo title="Property Change"><ToggleBox/></Demo>
-        <Demo title="On Demand"><TriggerBox/></Demo>
-        <Demo title="Custom Animation"><FlapBox/></Demo>
-        <Demo title="Custom Transition Group"><ScrollingGroup/></Demo>
-        <Demo title="Crossfade"><CrossfadeExample/></Demo>
-      </div>
+      <React.StrictMode>
+        <div className="flex-box flex-wrap">
+          <Demo title="Property Change">
+            <ToggleBox />
+          </Demo>
+          <Demo title="On Demand">
+            <TriggerBox />
+          </Demo>
+          <Demo title="Custom Animation">
+            <FlapBox />
+          </Demo>
+          <Demo title="Custom Transition Group">
+            <ScrollingGroup />
+          </Demo>
+          <Demo title="Crossfade">
+            <CrossfadeExample />
+          </Demo>
+        </div>
+      </React.StrictMode>
     );
   }
 }

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -15,12 +15,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         exclude: /(node_modules|bower_components)/,
-        loaders: ['react-hot', 'babel'],
-      },
-      {
-        test: /\.js?$/,
-        exclude: /(node_modules|bower_components)/,
-        loaders: ['react-hot'],
+        loaders: ['babel'],
       },
     ],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,193 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+      "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.44"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.5",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.44",
+        "@babel/template": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.44"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+      "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.2",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/generator": "7.0.0-beta.44",
+        "@babel/helper-function-name": "7.0.0-beta.44",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "debug": "3.1.0",
+        "globals": "11.4.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.5",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -20,18 +207,31 @@
       "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
       "dev": true
     },
-    "acorn-jsx": {
-      "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        }
       }
-    },
-    "ajv-keywords": {
-      "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
-      "dev": true
     },
     "align-text": {
       "version": "0.1.4",
@@ -54,11 +254,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
-    "ansi-escapes": {
-      "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
       "dev": true
     },
     "ansi-regex": {
@@ -117,28 +312,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-      "dev": true
-    },
-    "array-includes": {
-      "version": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-      "dev": true,
-      "requires": {
-        "define-properties": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-        "es-abstract": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz"
-      }
-    },
-    "array-union": {
-      "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
-      }
-    },
-    "array-uniq": {
-      "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
@@ -271,160 +444,48 @@
       }
     },
     "babel-eslint": {
-      "version": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.1.tgz",
-      "integrity": "sha1-XXGL56MoYl0AYCLrKT7TAIy9Y0Y=",
+      "version": "8.2.2",
+      "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
+      "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.22.tgz"
+        "@babel/code-frame": "7.0.0-beta.44",
+        "@babel/traverse": "7.0.0-beta.44",
+        "@babel/types": "7.0.0-beta.44",
+        "babylon": "7.0.0-beta.44",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          },
-          "dependencies": {
-            "color-convert": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-              "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-              "dev": true,
-              "requires": {
-                "color-name": "1.1.3"
-              }
-            }
-          }
-        },
-        "babel-code-frame": {
-          "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz",
-          "integrity": "sha1-QYp7Xz99yaRnDmGxFYtMVmG+yY0=",
-          "dev": true,
-          "requires": {
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-helper-function-name": {
-          "version": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.0.tgz",
-          "integrity": "sha1-0bZ3m2R+XFwx6+sF4TuZjk01LVY=",
-          "dev": true,
-          "requires": {
-            "babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.0.tgz",
-            "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.0.tgz",
-            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.0.tgz"
-          }
-        },
-        "babel-helper-get-function-arity": {
-          "version": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.0.tgz",
-          "integrity": "sha1-nRq3ITu17+HvFjio6hSJlptai24=",
-          "dev": true,
-          "requires": {
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.0.tgz"
-          }
-        },
-        "babel-messages": {
-          "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-beta.0.tgz",
-          "integrity": "sha1-bfASluSfyPvQY3OUMmoWfzbagXs=",
-          "dev": true
-        },
-        "babel-template": {
-          "version": "https://registry.npmjs.org/babel-template/-/babel-template-7.0.0-beta.0.tgz",
-          "integrity": "sha1-hQg8+eQ5XV5Iv1FU16jWmRyv7Ps=",
-          "dev": true,
-          "requires": {
-            "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.0.tgz",
-            "babylon": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.22.tgz",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-          }
-        },
-        "babel-traverse": {
-          "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz",
-          "integrity": "sha1-2hS+m3YvYqLwYNtGTqr92M0HKkE=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz",
-            "babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.0.tgz",
-            "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-7.0.0-beta.0.tgz",
-            "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.0.tgz",
-            "babylon": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.22.tgz",
-            "debug": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "globals": "https://registry.npmjs.org/globals/-/globals-10.1.0.tgz",
-            "invariant": "2.2.2",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-          }
-        },
-        "babel-types": {
-          "version": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.0.tgz",
-          "integrity": "sha1-64tuVWRw5tzErvmC15rSKUabUWk=",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
-          }
-        },
         "babylon": {
-          "version": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.22.tgz",
-          "integrity": "sha1-dPCtgu18fDz+q3TPaE+BUQQWG2U=",
+          "version": "7.0.0-beta.44",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
           "dev": true
         },
-        "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+        "eslint-scope": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+          "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
           "dev": true,
           "requires": {
-            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz"
+            "esrecurse": "4.2.1",
+            "estraverse": "4.2.0"
           }
         },
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+        "esrecurse": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+          "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
           "dev": true,
           "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            "estraverse": "4.2.0"
           }
         },
-        "globals": {
-          "version": "https://registry.npmjs.org/globals/-/globals-10.1.0.tgz",
-          "integrity": "sha1-RCWhiBvg0za0qCOoKnvnJdXdmHw=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
-          "dev": true,
-          "requires": {
-            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-          }
-        },
-        "to-fast-properties": {
-          "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
           "dev": true
         }
       }
@@ -1258,9 +1319,10 @@
         "isarray": "1.0.0"
       }
     },
-    "builtin-modules": {
-      "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true
     },
     "builtin-status-codes": {
@@ -1273,19 +1335,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
       "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo=",
-      "dev": true
-    },
-    "caller-path": {
-      "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
-      }
-    },
-    "callsites": {
-      "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
     "camelcase": {
@@ -1340,6 +1389,12 @@
         "supports-color": "2.0.0"
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -1363,11 +1418,6 @@
       "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
       "dev": true
     },
-    "circular-json": {
-      "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
-      "dev": true
-    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1375,14 +1425,6 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3"
-      }
-    },
-    "cli-cursor": {
-      "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz"
       }
     },
     "cli-spinners": {
@@ -1409,11 +1451,6 @@
         }
       }
     },
-    "cli-width": {
-      "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
-    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -1437,6 +1474,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "coa": {
@@ -1559,16 +1602,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
-      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-      }
-    },
     "connect-history-api-fallback": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
@@ -1588,11 +1621,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-      "dev": true
-    },
-    "contains-path": {
-      "version": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
     "content-disposition": {
@@ -1808,39 +1836,11 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
-    "deep-is": {
-      "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "define-properties": {
-      "version": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
-      "requires": {
-        "foreach": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-        "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-      }
-    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
-    },
-    "del": {
-      "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-        "is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-        "is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-        "object-assign": "4.1.1",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
-      }
     },
     "depd": {
       "version": "1.1.1",
@@ -1861,15 +1861,6 @@
       "dev": true,
       "requires": {
         "repeating": "2.0.1"
-      }
-    },
-    "doctrine": {
-      "version": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
       }
     },
     "dom-helpers": {
@@ -1957,35 +1948,6 @@
         "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
       }
     },
-    "es-abstract": {
-      "version": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
-      "integrity": "sha1-JRAyY9xN7L2mDgxzfKMjE1GAJ+4=",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-        "function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-        "has": "1.0.1",
-        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-        "is-regex": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
-      },
-      "dependencies": {
-        "function-bind": {
-          "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-          "dev": true
-        }
-      }
-    },
-    "es-to-primitive": {
-      "version": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
-      "requires": {
-        "is-callable": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-        "is-date-object": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-        "is-symbol": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
-      }
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1999,261 +1961,778 @@
       "dev": true
     },
     "eslint": {
-      "version": "https://registry.npmjs.org/eslint/-/eslint-4.7.2.tgz",
-      "integrity": "sha1-/29fUZOEiifum2J74+c/ucteZi4=",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
-        "ajv": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+        "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-        "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-        "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-        "eslint-scope": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-        "espree": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-        "esquery": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+        "chalk": "2.3.2",
+        "concat-stream": "1.6.2",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.1",
         "esutils": "2.0.2",
-        "file-entry-cache": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-        "functional-red-black-tree": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-        "globals": "9.18.0",
-        "ignore": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-        "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-        "inquirer": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-        "is-resolvable": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-        "json-stable-stringify": "1.0.1",
-        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.4.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.11.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "natural-compare": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-        "pluralize": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-        "progress": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-        "require-uncached": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "regexpp": "1.1.0",
+        "require-uncached": "1.0.3",
         "semver": "5.4.1",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+        "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
-        "table": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-        "text-table": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        "table": "4.0.2",
+        "text-table": "0.2.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+        "acorn": {
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-            "json-schema-traverse": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "json-stable-stringify": "1.0.1"
+            "acorn": "3.3.0"
           },
           "dependencies": {
-            "co": {
-              "version": "4.6.0",
-              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "acorn": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
               "dev": true
             }
           }
         },
+        "ajv-keywords": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+          "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+          "dev": true
+        },
+        "ansi-escapes": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+          "dev": true
+        },
         "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
-          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
         },
-        "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
           "dev": true,
           "requires": {
-            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+            "array-uniq": "1.0.3"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+          "dev": true
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+          "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+          "dev": true,
+          "requires": {
+            "callsites": "0.2.0"
+          }
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz"
+            "supports-color": "5.3.0"
+          }
+        },
+        "circular-json": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+          "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "2.0.0"
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+          "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+          "dev": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.2",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
           }
         },
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            "ms": "2.0.0"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+          "dev": true
+        },
+        "del": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+          "dev": true,
+          "requires": {
+            "globby": "5.0.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.2"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2"
+          }
+        },
+        "eslint-scope": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+          "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "4.2.1",
+            "estraverse": "4.2.0"
+          }
+        },
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.5.3",
+            "acorn-jsx": "3.0.1"
           }
         },
         "esprima": {
-          "version": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
           "dev": true
         },
-        "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+        "esquery": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+          "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "1.1.8"
-              }
-            }
+            "estraverse": "4.2.0"
+          }
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+          "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+          "dev": true,
+          "requires": {
+            "estraverse": "4.2.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "dev": true
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "requires": {
+            "chardet": "0.4.2",
+            "iconv-lite": "0.4.19",
+            "tmp": "0.0.33"
+          }
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+          "dev": true
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+          "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+          "dev": true,
+          "requires": {
+            "flat-cache": "1.3.0",
+            "object-assign": "4.1.1"
+          }
+        },
+        "flat-cache": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+          "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+          "dev": true,
+          "requires": {
+            "circular-json": "0.3.3",
+            "del": "2.2.2",
+            "graceful-fs": "4.1.11",
+            "write": "0.2.1"
+          }
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+          "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+          "dev": true
+        },
+        "globals": {
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+          "dev": true
+        },
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "has-flag": {
-          "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "ignore": {
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+          "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.3.2",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.2.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.5",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx-lite": "4.0.8",
+            "rx-lite-aggregates": "4.0.8",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+          "dev": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+          "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+          "dev": true,
+          "requires": {
+            "is-path-inside": "1.0.1"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "1.0.2"
+          }
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+          "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+          "dev": true
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+          "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "js-yaml": {
-          "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
             "argparse": "1.0.9",
-            "esprima": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
+            "esprima": "4.0.0"
           }
         },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
           }
         },
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+        "lru-cache": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
           "dev": true
         },
-        "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+        "mute-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "dev": true
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "1.2.0"
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+          "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
+          }
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+          "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "dev": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+          "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+          "dev": true,
+          "requires": {
+            "caller-path": "0.1.0",
+            "resolve-from": "1.0.1"
+          }
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "2.0.1",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+          "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+          "dev": true,
+          "requires": {
+            "is-promise": "2.1.0"
+          }
+        },
+        "rx-lite": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+          "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+          "dev": true
+        },
+        "rx-lite-aggregates": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+          "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+          "dev": true,
+          "requires": {
+            "rx-lite": "4.0.8"
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
         },
         "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+            "has-flag": "3.0.0"
           }
+        },
+        "table": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+          "dev": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "ajv-keywords": "2.1.1",
+            "chalk": "2.3.2",
+            "lodash": "4.17.5",
+            "slice-ansi": "1.0.0",
+            "string-width": "2.1.1"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "dev": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "1.1.2"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+          "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+          "dev": true,
+          "requires": {
+            "mkdirp": "0.5.1"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
         }
       }
     },
     "eslint-config-prettier": {
-      "version": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.6.0.tgz",
-      "integrity": "sha1-8h2w67Q4rWePuYlGCXxLsZi+/Mw=",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz",
+      "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
       "dev": true,
       "requires": {
-        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz"
-      }
-    },
-    "eslint-import-resolver-node": {
-      "version": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-      "integrity": "sha1-RCJXTN5mqaewmZOO5NUIoZng48w=",
-      "dev": true,
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+        "get-stdin": "5.0.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-          }
-        },
-        "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
-    },
-    "eslint-module-utils": {
-      "version": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
-      "dev": true,
-      "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "pkg-dir": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-          }
-        },
-        "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+        "get-stdin": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
           "dev": true
         }
       }
     },
     "eslint-plugin-import": {
-      "version": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
-      "integrity": "sha1-Id4zOAue+1X1720uIQ7A4H5/pp8=",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.11.0.tgz",
+      "integrity": "sha1-Fa7qN6Z0mdhI6OmBgG1GJ7VQOBY=",
       "dev": true,
       "requires": {
-        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-        "contains-path": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-        "eslint-import-resolver-node": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-        "eslint-module-utils": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.2.0",
         "has": "1.0.1",
-        "lodash.cond": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
-        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz"
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.7.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
-          "dev": true,
-          "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-          }
+        "builtin-modules": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "dev": true
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+          "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+          "dev": true
         },
         "doctrine": {
-          "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -2261,115 +2740,376 @@
             "isarray": "1.0.0"
           }
         },
-        "ms": {
-          "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+        "error-ex": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "eslint-import-resolver-node": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+          "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "resolve": "1.7.1"
+          }
+        },
+        "eslint-module-utils": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+          "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "pkg-dir": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
           "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "3.0.3"
+          }
+        },
+        "p-limit": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+          "dev": true,
+          "requires": {
+            "p-try": "1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "1.2.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+          "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+          "dev": true,
+          "requires": {
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
+          }
         }
       }
     },
     "eslint-plugin-prettier": {
-      "version": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz",
-      "integrity": "sha1-56dGxn5xbzNSdLiClanq2fVE5E0=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz",
+      "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
       "dev": true,
       "requires": {
-        "fast-diff": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-        "jest-docblock": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz"
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      },
+      "dependencies": {
+        "fast-diff": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+          "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+          "dev": true
+        },
+        "jest-docblock": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+          "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-react": {
-      "version": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.4.0.tgz",
-      "integrity": "sha1-MAqVhhuXKcCH02LdZKvMNRp0Nko=",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
+      "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
       "dev": true,
       "requires": {
-        "doctrine": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+        "doctrine": "2.1.0",
         "has": "1.0.1",
-        "jsx-ast-utils": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-        "prop-types": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz"
+        "jsx-ast-utils": "2.0.1",
+        "prop-types": "15.6.0"
       },
       "dependencies": {
-        "core-js": {
-          "version": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+        "array-includes": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+          "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+          "dev": true,
+          "requires": {
+            "define-properties": "1.1.2",
+            "es-abstract": "1.11.0"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+          "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+          "dev": true,
+          "requires": {
+            "foreach": "2.0.5",
+            "object-keys": "1.0.11"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2"
+          }
+        },
+        "es-abstract": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+          "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "1.1.1",
+            "function-bind": "1.1.1",
+            "has": "1.0.1",
+            "is-callable": "1.1.3",
+            "is-regex": "1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+          "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+          "dev": true,
+          "requires": {
+            "is-callable": "1.1.3",
+            "is-date-object": "1.0.1",
+            "is-symbol": "1.0.1"
+          }
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+          "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
           "dev": true
         },
-        "fbjs": {
-          "version": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+        "is-callable": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+          "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+          "dev": true
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
           "dev": true,
           "requires": {
-            "core-js": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.14"
+            "has": "1.0.1"
           }
         },
-        "prop-types": {
-          "version": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-          "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+        "is-symbol": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+          "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+          "dev": true
+        },
+        "jsx-ast-utils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+          "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
           "dev": true,
           "requires": {
-            "fbjs": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
+            "array-includes": "3.0.3"
           }
+        },
+        "object-keys": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+          "dev": true
         }
       }
     },
-    "eslint-scope": {
-      "version": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-      }
-    },
-    "espree": {
-      "version": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
-      "dev": true,
-      "requires": {
-        "acorn": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-        "acorn-jsx": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-          "integrity": "sha1-kRy1PgNoB88Pp3jcXTcPvYZCRtc=",
-          "dev": true
-        }
-      }
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
     },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-      "dev": true
-    },
-    "esquery": {
-      "version": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true,
-      "requires": {
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-      }
-    },
-    "esrecurse": {
-      "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true,
-      "requires": {
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-        "object-assign": "4.1.1"
-      }
-    },
-    "estraverse": {
-      "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
@@ -2480,23 +3220,6 @@
         "vary": "1.1.2"
       }
     },
-    "external-editor": {
-      "version": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha1-UsJJo5gbm6GHx8rPW+tQvx2Rprw=",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-        "jschardet": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-        "tmp": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs=",
-          "dev": true
-        }
-      }
-    },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -2506,19 +3229,10 @@
         "is-extglob": "1.0.0"
       }
     },
-    "fast-deep-equal": {
-      "version": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-      "dev": true
-    },
-    "fast-diff": {
-      "version": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha1-S2LEK44D3j+EhGC2OQeZIGldAVQ=",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fastparse": {
@@ -2548,23 +3262,6 @@
         "promise": "7.3.1",
         "setimmediate": "1.0.5",
         "ua-parser-js": "0.7.14"
-      }
-    },
-    "figures": {
-      "version": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
-    },
-    "file-entry-cache": {
-      "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-        "object-assign": "4.1.1"
       }
     },
     "filename-regex": {
@@ -2622,17 +3319,6 @@
         "pinkie-promise": "2.0.1"
       }
     },
-    "flat-cache": {
-      "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-      "dev": true,
-      "requires": {
-        "circular-json": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-        "del": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-        "graceful-fs": "4.1.11",
-        "write": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
-      }
-    },
     "flatten": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -2653,11 +3339,6 @@
       "requires": {
         "for-in": "1.0.2"
       }
-    },
-    "foreach": {
-      "version": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -3452,14 +4133,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3468,6 +4141,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3588,20 +4269,10 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "functional-red-black-tree": {
-      "version": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
-    },
     "get-own-enumerable-property-symbols": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
       "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
     "get-stream": {
@@ -3649,19 +4320,6 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
-    "globby": {
-      "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "2.0.1"
-      }
-    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -3701,11 +4359,6 @@
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
       }
-    },
-    "hosted-git-info": {
-      "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
-      "dev": true
     },
     "html-comment-regex": {
       "version": "1.1.1",
@@ -3812,16 +4465,6 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
     },
-    "ignore": {
-      "version": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-      "integrity": "sha1-xOcVRV9gc6jX5drnLS/J1xZj26Y=",
-      "dev": true
-    },
-    "imurmurhash": {
-      "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -3858,92 +4501,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
-    },
-    "inquirer": {
-      "version": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-        "cli-cursor": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-        "cli-width": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-        "external-editor": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-        "figures": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-        "run-async": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-        "rx-lite-aggregates": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz"
-          }
-        },
-        "has-flag": {
-          "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
-          }
-        },
-        "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
-          }
-        },
-        "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
-          "dev": true,
-          "requires": {
-            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-          }
-        }
-      }
     },
     "interpret": {
       "version": "0.6.6",
@@ -3992,19 +4549,6 @@
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
-    "is-builtin-module": {
-      "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-      }
-    },
-    "is-callable": {
-      "version": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
-    },
     "is-ci": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
@@ -4013,11 +4557,6 @@
       "requires": {
         "ci-info": "1.1.1"
       }
-    },
-    "is-date-object": {
-      "version": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -4088,27 +4627,6 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
-    "is-path-cwd": {
-      "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
-      }
-    },
-    "is-path-inside": {
-      "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
-      }
-    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -4132,27 +4650,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-regex": {
-      "version": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1"
-      }
-    },
     "is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
-    },
-    "is-resolvable": {
-      "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
-      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -4167,11 +4669,6 @@
       "requires": {
         "html-comment-regex": "1.1.1"
       }
-    },
-    "is-symbol": {
-      "version": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -4201,11 +4698,6 @@
         "node-fetch": "1.7.3",
         "whatwg-fetch": "2.0.3"
       }
-    },
-    "jest-docblock": {
-      "version": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha1-UVKcOzDV/RWdpgwnzu3Blfr41BQ=",
-      "dev": true
     },
     "jest-get-type": {
       "version": "21.2.0",
@@ -4283,20 +4775,16 @@
         "esprima": "2.7.3"
       }
     },
-    "jschardet": {
-      "version": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha1-xRn2KfhrOlvtuliojTETCe7Al/k=",
-      "dev": true
-    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
-    "json-schema-traverse": {
-      "version": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json3": {
@@ -4310,20 +4798,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
-    "jsx-ast-utils": {
-      "version": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
-      "dev": true,
-      "requires": {
-        "array-includes": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz"
-      }
     },
     "kind-of": {
       "version": "3.2.2",
@@ -4345,15 +4819,6 @@
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
       "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
       "dev": true
-    },
-    "levn": {
-      "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-      }
     },
     "lint-staged": {
       "version": "4.2.3",
@@ -4578,17 +5043,6 @@
         }
       }
     },
-    "load-json-file": {
-      "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
-      }
-    },
     "loader-utils": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
@@ -4601,31 +5055,10 @@
         "object-assign": "4.1.1"
       }
     },
-    "locate-path": {
-      "version": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
-      "requires": {
-        "p-locate": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
-      },
-      "dependencies": {
-        "path-exists": {
-          "version": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        }
-      }
-    },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-    },
-    "lodash.cond": {
-      "version": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
-      "dev": true
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -4833,11 +5266,6 @@
         "mime-db": "1.30.0"
       }
     },
-    "mimic-fn": {
-      "version": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -4868,22 +5296,12 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "mute-stream": {
-      "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
     "nan": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
       "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
       "dev": true,
       "optional": true
-    },
-    "natural-compare": {
-      "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -4937,17 +5355,6 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
-      }
-    },
-    "normalize-package-data": {
-      "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-        "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
       }
     },
     "normalize-path": {
@@ -5023,11 +5430,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
-    "object-keys": {
-      "version": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-      "dev": true
-    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -5062,14 +5464,6 @@
         "wrappy": "1.0.2"
       }
     },
-    "onetime": {
-      "version": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
-      }
-    },
     "open": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
@@ -5084,26 +5478,6 @@
       "requires": {
         "minimist": "0.0.8",
         "wordwrap": "0.0.3"
-      }
-    },
-    "optionator": {
-      "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-        "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
-        }
       }
     },
     "ora": {
@@ -5201,23 +5575,16 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
-    "p-limit": {
-      "version": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
-    },
-    "p-locate": {
-      "version": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
-      "requires": {
-        "p-limit": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz"
-      }
-    },
     "p-map": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "pako": {
@@ -5273,20 +5640,10 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-is-inside": {
-      "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
-    },
-    "path-parse": {
-      "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-to-regexp": {
@@ -5295,29 +5652,10 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
-    "path-type": {
-      "version": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "dev": true,
-      "requires": {
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-      }
-    },
     "pbkdf2-compat": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
       "integrity": "sha1-tuDI+plJTZTgURV1gCpZpcFC8og=",
-      "dev": true
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
-    },
-    "pify": {
-      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
@@ -5343,11 +5681,6 @@
       "requires": {
         "find-up": "1.1.2"
       }
-    },
-    "pluralize": {
-      "version": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
-      "dev": true
     },
     "postcss": {
       "version": "5.2.17",
@@ -5685,11 +6018,6 @@
         "uniqs": "2.0.0"
       }
     },
-    "prelude-ls": {
-      "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
     "prepend-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
@@ -5703,8 +6031,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "https://registry.npmjs.org/prettier/-/prettier-1.7.0.tgz",
-      "integrity": "sha1-R0gViPQffJD2OTj+sgKsglVOcVA=",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.0.tgz",
+      "integrity": "sha512-Wz0SMncgaglBzDcohH3ZIAi4nVpzOIEweFzCOmgVEoRSeO72b4dcKGfgxoRGVMaFlh1r7dlVaJ+f3CIHfeH6xg==",
       "dev": true
     },
     "pretty-format": {
@@ -5750,11 +6079,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
-    },
-    "progress": {
-      "version": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
     "promise": {
@@ -5842,15 +6166,6 @@
       "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
       "dev": true
     },
-    "raf": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.3.2.tgz",
-      "integrity": "sha1-DBO+C1tJtG921maSSNUnzysC/ic=",
-      "dev": true,
-      "requires": {
-        "performance-now": "2.1.0"
-      }
-    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -5899,12 +6214,11 @@
       "dev": true
     },
     "react": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-      "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.3.1.tgz",
+      "integrity": "sha512-NbkxN9jsZ6+G+ICsLdC7/wUD26uNbvKU/RAxEWgc9kcdKvROt+5d5j2cNQm5PSFTQ4WNGsR3pa4qL2Q0/WSy1w==",
       "dev": true,
       "requires": {
-        "create-react-class": "15.6.2",
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
@@ -5912,9 +6226,9 @@
       }
     },
     "react-dom": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
-      "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.1.tgz",
+      "integrity": "sha512-2Infg89vzahq8nfVi1GkjPqq0vrBvf0f3T0+dTtyjq4f6HKOqKixAK25Vr593O3QTx4kw/vmUtAJwerlevNWOA==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.16",
@@ -5923,82 +6237,16 @@
         "prop-types": "15.6.0"
       }
     },
-    "react-hot-api": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/react-hot-api/-/react-hot-api-0.4.7.tgz",
-      "integrity": "sha1-p+IqVtJS4Rq9k2a2EmTPRJLFgXE=",
-      "dev": true
-    },
-    "react-hot-loader": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-1.3.1.tgz",
-      "integrity": "sha1-yVZHrni3Pfzv9uxx/8sEGC/22vk=",
-      "dev": true,
-      "requires": {
-        "react-hot-api": "0.4.7",
-        "source-map": "0.4.4"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
-      }
-    },
     "react-transition-group": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.0.tgz",
-      "integrity": "sha1-tR/JIbDDg1p+98Vxx5/ILHPpIE8=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.0.tgz",
+      "integrity": "sha512-OU3/swEL8y233u5ajTn3FIcQQ/b3XWjLXB6e2LnM1OK5JATtsyfJvPTZ8c/dawHNqjUltcdHRSpgMtPe7v07pw==",
       "requires": {
         "chain-function": "1.0.0",
         "dom-helpers": "3.2.1",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.0",
         "warning": "3.0.0"
-      }
-    },
-    "react-tween-state": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/react-tween-state/-/react-tween-state-0.1.5.tgz",
-      "integrity": "sha1-6YsGZVHvuTy5LdG+FJlcLj3q4zk=",
-      "dev": true,
-      "requires": {
-        "raf": "3.3.2",
-        "tween-functions": "1.2.0"
-      }
-    },
-    "read-pkg": {
-      "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-        "path-type": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz"
-      }
-    },
-    "read-pkg-up": {
-      "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-      "dev": true,
-      "requires": {
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-        "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
-          }
-        }
       }
     },
     "readable-stream": {
@@ -6096,6 +6344,12 @@
         "is-equal-shallow": "0.1.3"
       }
     },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
@@ -6163,42 +6417,11 @@
       "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
       "dev": true
     },
-    "require-uncached": {
-      "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
-      }
-    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
-    },
-    "resolve": {
-      "version": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
-      "dev": true,
-      "requires": {
-        "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
-      }
-    },
-    "resolve-from": {
-      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
-    },
-    "restore-cursor": {
-      "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-        "signal-exit": "3.0.2"
-      }
     },
     "right-align": {
       "version": "0.1.3",
@@ -6223,27 +6446,6 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
       "integrity": "sha1-K/GYveFnys+lHAqSjoS2i74XH84=",
       "dev": true
-    },
-    "run-async": {
-      "version": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
-      }
-    },
-    "rx-lite": {
-      "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
-      "requires": {
-        "rx-lite": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz"
-      }
     },
     "rxjs": {
       "version": "5.4.3",
@@ -6379,21 +6581,6 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
-    "slice-ansi": {
-      "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        }
-      }
-    },
     "sockjs": {
       "version": "0.3.18",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
@@ -6459,22 +6646,10 @@
         "source-map": "0.5.7"
       }
     },
-    "spdx-correct": {
-      "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
-      "requires": {
-        "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-      }
-    },
-    "spdx-expression-parse": {
-      "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
-    },
-    "spdx-license-ids": {
-      "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
     "sprintf-js": {
@@ -6536,15 +6711,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -6554,6 +6720,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {
@@ -6575,11 +6750,6 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
-    },
-    "strip-bom": {
-      "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
@@ -6635,126 +6805,10 @@
       "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
       "dev": true
     },
-    "table": {
-      "version": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
-      "dev": true,
-      "requires": {
-        "ajv": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-        "ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "slice-ansi": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-          "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-            "json-schema-traverse": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "json-stable-stringify": "1.0.1"
-          },
-          "dependencies": {
-            "co": {
-              "version": "4.6.0",
-              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-              "dev": true
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-              "dev": true,
-              "requires": {
-                "jsonify": "0.0.0"
-              }
-            }
-          }
-        },
-        "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz"
-          }
-        },
-        "has-flag": {
-          "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz"
-          }
-        },
-        "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
-          }
-        },
-        "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
-          "dev": true,
-          "requires": {
-            "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-          }
-        }
-      }
-    },
     "tapable": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
       "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
-      "dev": true
-    },
-    "text-table": {
-      "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "through": {
-      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "time-stamp": {
@@ -6770,14 +6824,6 @@
       "dev": true,
       "requires": {
         "setimmediate": "1.0.5"
-      }
-    },
-    "tmp": {
-      "version": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -6798,21 +6844,10 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
-    "tryit": {
-      "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
-    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
-      "dev": true
-    },
-    "tween-functions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
-      "integrity": "sha1-GuOlDnxguz3vd06scHrLynO7w/8=",
       "dev": true
     },
     "twemoji": {
@@ -6820,14 +6855,6 @@
       "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-1.4.1.tgz",
       "integrity": "sha1-CEfVf+/t/3Kxv9v+4G+CJRBmNHE=",
       "dev": true
-    },
-    "type-check": {
-      "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-      }
     },
     "type-is": {
       "version": "1.6.15",
@@ -6838,11 +6865,6 @@
         "media-typer": "0.3.0",
         "mime-types": "2.1.17"
       }
-    },
-    "typedarray": {
-      "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.14",
@@ -6996,15 +7018,6 @@
       "dev": true,
       "requires": {
         "user-home": "1.1.1"
-      }
-    },
-    "validate-npm-package-license": {
-      "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-        "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
       }
     },
     "vary": {
@@ -7224,14 +7237,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "write": {
-      "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "velocity-react",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "React components to wrap Velocity animations",
   "main": "index.js",
   "scripts": {
     "compile": "babel src --out-dir .",
     "demo": "webpack-dev-server --progress --colors --content-base demo --hot --inline --config demo/webpack.config.js",
-    "prepublish": "npm run compile"
+    "prepare": "npm run compile"
   },
   "repository": {
     "type": "git",
@@ -27,9 +27,9 @@
     "*.js": "eslint --quiet"
   },
   "dependencies": {
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.5",
     "prop-types": "^15.5.8",
-    "react-transition-group": "^1.1.2",
+    "react-transition-group": "^2.0.0",
     "velocity-animate": "^1.4.0"
   },
   "peerDependencies": {
@@ -55,10 +55,8 @@
     "husky": "^0.14.3",
     "lint-staged": "^4.2.3",
     "prettier": "^1.7.0",
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0",
-    "react-hot-loader": "^1.2.9",
-    "react-tween-state": "^0.1.3",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "style-loader": "^0.12.3",
     "twemoji": "^1.4.1",
     "underscore.string": "^3.2.0",

--- a/src/velocity-component.js
+++ b/src/velocity-component.js
@@ -39,10 +39,10 @@ Methods:
 /* eslint react/no-find-dom-node: 0 */
 
 var _ = {
-  forEach: require('lodash/collection/forEach'),
-  isEqual: require('lodash/lang/isEqual'),
-  keys: require('lodash/object/keys'),
-  omit: require('lodash/object/omit'),
+  forEach: require('lodash/forEach'),
+  isEqual: require('lodash/isEqual'),
+  keys: require('lodash/keys'),
+  omit: require('lodash/omit'),
 };
 
 var React = require('react');
@@ -71,11 +71,11 @@ class VelocityComponent extends React.Component {
     }
   }
 
-  componentWillUpdate(newProps) {
-    if (!_.isEqual(newProps.animation, this.props.animation)) {
-      if (newProps.interruptBehavior === 'stop') {
+  componentDidUpdate(oldProps) {
+    if (!_.isEqual(oldProps.animation, this.props.animation)) {
+      if (this.props.interruptBehavior === 'stop') {
         this._stopAnimation();
-      } else if (newProps.interruptBehavior === 'finish') {
+      } else if (this.props.interruptBehavior === 'finish') {
         this._finishAnimation();
       }
 

--- a/src/velocity-helpers.js
+++ b/src/velocity-helpers.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015 Twitter, Inc. and other contributors
 
 var _ = {
-  isObject: require('lodash/lang/isObject'),
+  isObject: require('lodash/isObject'),
 };
 var Velocity = require('./lib/velocity-animate-shim');
 


### PR DESCRIPTION
 - Changes our `componentWillUpdate` call to `componentDidUpdate` to eliminate a
   React 16.3 StrictMode warning
 - Migration to [react-transition-group](https://github.com/reactjs/react-transition-group) v2
 - Switches from lodash 3 to lodash 4
 - Changes demo to use React 16.3

Also, removes `react-tween-state` because it was contributing to a
potential memory leak in the demo.

Fixes #237, fixes #236, fixes #235, fixes #229, fixes #222, fixes #224

Closes #233