### PR TITLE
Removes Promise dependency

### DIFF
--- a/demo/main.jsx
+++ b/demo/main.jsx
@@ -43,25 +43,23 @@ class Demo extends React.Component {
 class MainComponent extends React.Component {
   render() {
     return (
-      <React.StrictMode>
-        <div className="flex-box flex-wrap">
-          <Demo title="Property Change">
-            <ToggleBox />
-          </Demo>
-          <Demo title="On Demand">
-            <TriggerBox />
-          </Demo>
-          <Demo title="Custom Animation">
-            <FlapBox />
-          </Demo>
-          <Demo title="Custom Transition Group">
-            <ScrollingGroup />
-          </Demo>
-          <Demo title="Crossfade">
-            <CrossfadeExample />
-          </Demo>
-        </div>
-      </React.StrictMode>
+      <div className="flex-box flex-wrap">
+        <Demo title="Property Change">
+          <ToggleBox />
+        </Demo>
+        <Demo title="On Demand">
+          <TriggerBox />
+        </Demo>
+        <Demo title="Custom Animation">
+          <FlapBox />
+        </Demo>
+        <Demo title="Custom Transition Group">
+          <ScrollingGroup />
+        </Demo>
+        <Demo title="Crossfade">
+          <CrossfadeExample />
+        </Demo>
+      </div>
     );
   }
 }


### PR DESCRIPTION
Avoids needing to polyfill for IE11.

Also removes <StrictMode> from the demo, since that also doesn't work on
IE 11 without a polyfill.